### PR TITLE
Fixing failing tests

### DIFF
--- a/src/Datetime-fns/Comparison/Comparison.test.ts
+++ b/src/Datetime-fns/Comparison/Comparison.test.ts
@@ -25,6 +25,7 @@ import {
   isSunday,
 } from '.'
 import { EthiopicDatetime } from '../../Datetime'
+import { toEthiopic } from "../../Calendar/Convertor";
 
 describe('isEqual', () => {
   test('should return true if the given dates are equal', () => {
@@ -594,8 +595,10 @@ describe('isFuture', () => {
 
 describe('isYesterday', () => {
   test('should return true if the date is yesterday', () => {
-    const today = new EthiopicDatetime(2013, 5, 17)
-    expect(isYesterday(today)).toBeTruthy()
+    const yesterdayInGc = new Date(Date.now() - 86400000)
+    const yesterday = toEthiopic(yesterdayInGc.getFullYear(), yesterdayInGc.getMonth() + 1, yesterdayInGc.getDate())
+    const yesterdayInEC = new EthiopicDatetime(yesterday.year, yesterday.month, yesterday.day)
+    expect(isYesterday(yesterdayInEC)).toBeTruthy()
   })
 
   test('should return false if the date is other than yesterday', () => {

--- a/src/Datetime-fns/Comparison/Comparison.test.ts
+++ b/src/Datetime-fns/Comparison/Comparison.test.ts
@@ -561,7 +561,7 @@ describe('isPast', () => {
 
   test('should return false if the date is greater than or equal to today', () => {
     expect(isPast(new EthiopicDatetime())).toBeFalsy()
-    expect(isPast(new EthiopicDatetime(2013, 5, 19))).toBeFalsy()
+    expect(isPast(new EthiopicDatetime(2113, 5, 19))).toBeFalsy()
   })
 
   test('should return false if the date is `Invalid EthiopicDatetime`', () => {
@@ -575,7 +575,7 @@ describe('isPast', () => {
 
 describe('isFuture', () => {
   test('should return true if the date is greater than today', () => {
-    expect(isFuture(new EthiopicDatetime(2013, 5, 20))).toBeTruthy()
+    expect(isFuture(new EthiopicDatetime(2113, 5, 20))).toBeTruthy()
   })
 
   test('should return false if the date is less than or equal to today', () => {


### PR DESCRIPTION
There are 3 failing tests caused by incorrectly set dates. 

![image](https://user-images.githubusercontent.com/32495495/140703336-aabd137f-2a6f-4138-99f4-ac5d74be3140.png)

I fixed those tests by pushing the future date further back and by generating the yesterday value from the built-in js date class.